### PR TITLE
chore: symlink .cursorrules to .agent/rules.md

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,1 @@
+.agent/rules.md


### PR DESCRIPTION
This PR replaces .cursorrules with a symbolic link to .agent/rules.md to ensure project rules are consistently applied across all agents.