### PR TITLE
chore: remove verbose logging from test reporter

### DIFF
--- a/tests/markdown-reporter.ts
+++ b/tests/markdown-reporter.ts
@@ -72,11 +72,5 @@ export default class MarkdownReporter {
     }
 
     fs.writeFileSync(reportPath, reportContent);
-    
-    // Log clearly to terminal
-    console.log('\n--- Markdown Report Generated ---');
-    console.log(`Updated: ${suiteResultsPath}`);
-    console.log(`Updated: ${reportPath}`);
-    console.log('--------------------------------\n');
   }
 }


### PR DESCRIPTION
Removed console logs from markdown-reporter.ts to keep test output clean.