### PR TITLE
feat(scorer): improve UX with responsive layout and touch targets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,8 @@ Auto-generated from all feature plans. Last updated: 2026-03-01
 - PostgreSQL 16 via Drizzle ORM, Hasura GraphQL for real-time subscriptions (078-configurable-player-stats)
 - TypeScript 5.x (strict mode, no escape hatches per constitution) + Next.js 15 (App Router), React 19, Framer Motion, Tailwind CSS (079-shot-ratio-display)
 - N/A (client-side calculation from existing events array) (079-shot-ratio-display)
+- TypeScript 5.x (strict mode, no escape hatches per constitution) + Next.js 15 (App Router) + React 19, Framer Motion, Tailwind CSS, Zustand (080-scorer-ux-improvements)
+- N/A (UI changes only, no new data entities) (080-scorer-ux-improvements)
 
 - TypeScript 5.x (strict mode, no escape hatches per constitution) + Next.js 15 (App Router), Drizzle ORM, Hasura GraphQL (WebSocket subscriptions), Clerk (auth), Zustand, Vitest, @testing-library/react (002-multi-scorer-testing)
 
@@ -30,9 +32,9 @@ npm test && npm run lint
 TypeScript 5.x (strict mode, no escape hatches per constitution): Follow standard conventions
 
 ## Recent Changes
+- 080-scorer-ux-improvements: Added TypeScript 5.x (strict mode, no escape hatches per constitution) + Next.js 15 (App Router) + React 19, Framer Motion, Tailwind CSS, Zustand
 - 079-shot-ratio-display: Added TypeScript 5.x (strict mode, no escape hatches per constitution) + Next.js 15 (App Router), React 19, Framer Motion, Tailwind CSS
 - 078-configurable-player-stats: Added TypeScript 5.x (strict mode) + Next.js 15 (App Router), Drizzle ORM, Hasura GraphQL, Zustand, Framer Motion
-- 078-fix-period-advance: Added TypeScript 5.x (strict mode, no escape hatches) + Next.js 16 (App Router), Hasura GraphQL WebSocket, Vitest + @testing-library/react
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hoophoop",
-  "version": "0.2.0-alpha",
+  "version": "0.2.1-alpha",
   "private": true,
   "scripts": {
     "dev": "nodemon server.ts",

--- a/specs/080-scorer-ux-improvements/checklists/requirements.md
+++ b/specs/080-scorer-ux-improvements/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Scorer Page UX Improvements
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-17
+**Feature**: [spec.md](./spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation
+- Specification is ready for `/speckit.plan`
+- No clarifications needed - all requirements are well-defined
+- Success criteria are measurable and technology-agnostic
+- Edge cases cover the key boundary conditions

--- a/specs/080-scorer-ux-improvements/data-model.md
+++ b/specs/080-scorer-ux-improvements/data-model.md
@@ -1,0 +1,176 @@
+# Data Model: Scorer Page UX Improvements
+
+**Feature**: 080-scorer-ux-improvements  
+**Date**: 2026-03-17
+
+## Overview
+
+This feature is primarily UI/UX focused with minimal new data entities. The changes involve React state management for quick-repeat functionality and mutation feedback, but no new database schemas or API endpoints.
+
+## New UI State Entities
+
+### LastScorerState
+
+Tracks the most recent scorer for quick-repeat functionality.
+
+```typescript
+interface LastScorerState {
+  playerId: string | null;
+  playerName: string | null;
+  team: 'home' | 'guest' | null;
+  points: 1 | 2 | 3 | null;
+  timestamp: number; // When last scored (for expiration)
+}
+```
+
+**Lifecycle**:
+- Created when player scores successfully
+- Cleared on: substitution, timeout, period end, team change
+- Not persisted (session-only, lost on page refresh)
+
+**Location**: `src/app/game/[id]/scorer/page.tsx` as React state
+
+### MutationFeedbackState
+
+Tracks in-flight mutations for visual feedback.
+
+```typescript
+interface PendingMutation {
+  id: string;           // Unique mutation identifier
+  type: 'score' | 'foul' | 'timeout' | 'sub';
+  target: string;      // UI element identifier
+  startedAt: number;
+}
+
+interface MutationFeedbackState {
+  pending: Set<string>; // Active mutation IDs
+  lastSuccess: { type: string; timestamp: number } | null;
+  lastError: { type: string; message: string } | null;
+}
+```
+
+**Lifecycle**:
+- Created when mutation starts
+- Updated on success/error
+- Cleared after timeout (5s for success, 10s for error)
+
+**Location**: `src/app/game/[id]/scorer/page.tsx` as React state
+
+## Modified Existing Entities
+
+### ScoringModalProps
+
+Extended to support pre-selection.
+
+```typescript
+// Before
+interface ScoringModalProps {
+  game: Game;
+  scoringFor: { points: number; side?: 'home' | 'guest'; isMiss?: boolean };
+  onClose: () => void;
+  onScore: (playerId: string | null, team: 'home' | 'guest') => void;
+}
+
+// After
+interface ScoringModalProps {
+  game: Game;
+  scoringFor: { 
+    points: number; 
+    side?: 'home' | 'guest'; 
+    isMiss?: boolean;
+    preSelectedPlayerId?: string; // NEW
+  };
+  onClose: () => void;
+  onScore: (playerId: string | null, team: 'home' | 'guest') => void;
+}
+```
+
+## Touch Target Constants
+
+No database entities, but new shared constants for consistent sizing.
+
+```typescript
+// src/lib/constants/touch-targets.ts
+
+export const TOUCH_TARGETS = {
+  // WCAG 2.5.5 Level AAA minimum
+  primary: 'min-h-[48px] min-w-[48px]',
+  // Secondary actions (slightly smaller acceptable)
+  secondary: 'min-h-[44px] min-w-[44px]',
+  // Icon-only buttons (with padding)
+  icon: 'min-h-[32px] min-w-[32px] p-2',
+} as const;
+
+export const VISUAL_SIZES = {
+  // Text sizes for period/clock displays
+  periodPortrait: 'text-sm',     // 14pt
+  periodLandscape: 'text-xs',    // 12pt
+  clockPortrait: 'text-4xl',     // 36pt
+  clockLandscape: 'text-3xl',   // 28pt
+  // Icon sizes
+  gameLogIcon: 20,              // Up from 12
+  connectionIndicator: 'w-3 h-3', // Up from w-2 h-2
+} as const;
+
+export const ANIMATION_DURATIONS = {
+  mutationFeedback: 100, // ms - visible feedback delay
+  debounceWindow: 300,   // ms - minimum time between same actions
+} as const;
+```
+
+## Data Flow
+
+### Quick-Repeat Flow
+
+```
+User taps +2
+    ↓
+ScoringModal opens
+    ↓
+User selects Player A
+    ↓
+Score recorded
+    ↓
+Modal closes
+    ↓
+lastScorerState = { playerId: A, points: 2, timestamp: now }
+    ↓
+QuickRepeatButton appears (portrait/landscape)
+    ↓
+User taps QuickRepeatButton
+    ↓
+ScoringModal opens with preSelectedPlayerId: A
+    ↓
+User taps +2 (one tap, same player)
+    ↓
+Score recorded
+```
+
+### Mutation Feedback Flow
+
+```
+User taps button
+    ↓
+setPendingMutations(prev => prev.add(mutationId))
+    ↓
+Button shows subtle pulse animation
+    ↓
+Mutation completes (success)
+    ↓
+setPendingMutations(prev => prev.delete(mutationId))
+setLastSuccess({ type: 'score', timestamp: now })
+    ↓
+Button shows brief success color (green flash)
+    ↓
+After 5s, clear lastSuccess
+```
+
+## No Database Changes
+
+This feature requires:
+- No new tables
+- No new columns
+- No migrations
+- No API endpoint changes
+
+All changes are in React state and CSS classes.

--- a/specs/080-scorer-ux-improvements/plan.md
+++ b/specs/080-scorer-ux-improvements/plan.md
@@ -1,0 +1,240 @@
+# Implementation Plan: Scorer Page UX Improvements
+
+**Branch**: `080-scorer-ux-improvements` | **Date**: 2026-03-17 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/080-scorer-ux-improvements/spec.md`
+
+## Summary
+
+Improve the scorer page UI for responsive design across mobile portrait, mobile landscape, tablet, and PC. Focus on: (1) Adding a "quick repeat" shortcut after player scoring to reduce clicks from 3 to 2, (2) Increasing touch target sizes to meet WCAG 2.5.5 minimums, (3) Improving legibility of period/clock displays, (4) Optimizing landscape layout for narrow devices, (5) Adding visual feedback during scoring mutations.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x (strict mode, no escape hatches per constitution) + Next.js 15 (App Router)
+**Primary Dependencies**: React 19, Framer Motion, Tailwind CSS, Zustand
+**Storage**: N/A (UI changes only, no new data entities)
+**Testing**: Vitest + @testing-library/react
+**Target Platform**: Mobile web (portrait primary), Tablet (landscape), Desktop (secondary)
+**Project Type**: Web application (frontend-focused)
+**Performance Goals**: < 100ms visual feedback on user action, < 500ms mutation sync per constitution
+**Constraints**: Touch targets ≥ 44×44pt WCAG 2.5.5, real-time propagation < 500ms per constitution
+**Scale/Scope**: Single scorer page with 5 user stories affecting ~10 components
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Real-Time First | ✅ PASS | Visual feedback adds to existing real-time sync infrastructure |
+| II. Mobile-First Design | ✅ PASS | Core requirement aligns with constitution - touch targets ≥ 48×48pt |
+| III. Data Integrity Over Convenience | ✅ PASS | Debounce prevents duplicate mutations, maintains data integrity |
+| IV. Permission Hierarchy | ✅ PASS | No permission changes, UI-only feature |
+| V. Test Coverage | ✅ PASS | Will add Vitest tests for new components and interactions |
+| VI. TypeScript Strict Mode | ✅ PASS | No `as any`, `@ts-ignore`, or escape hatches |
+| VII. Incremental Complexity | ✅ PASS | Simplest implementation: CSS classes + React state for quick-repeat |
+
+**Gate Status**: ✅ ALL CHECKS PASS - Noviolations
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/080-scorer-ux-improvements/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output (minimal - UI state only)
+├── quickstart.md        # Phase 1 output
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── app/game/[id]/scorer/
+│   └── page.tsx                     # Main scorer page (modifications)
+├── components/scorer/
+│   ├── simple-scorer.tsx            # Simple mode (touch target fixes)
+│   ├── advanced-scorer.tsx          # Advanced mode (quick-repeat)
+│   ├── scoring-modal.tsx            # Player selection (pre-selection)
+│   ├── game-log.tsx                 # Event log (icon size fixes)
+│   ├── quick-repeat-button.tsx      # NEW: Quick repeat shortcut component
+│   └── mutation-feedback.tsx        # NEW: Visual feedback for mutations
+├── hooks/
+│   └── use-hasura-game.ts           # Mutation state tracking (modifications)
+└── styles/
+    └── scorer-tailwind.css          # NEW: Touch target constants (optional)
+
+tests/
+├── components/scorer/
+│   ├── quick-repeat-button.test.tsx # NEW: Unit tests
+│   └── mutation-feedback.test.tsx   # NEW: Unit tests
+└── e2e/
+    └── scorer-ux.spec.ts            # NEW: E2E tests for touch targets
+```
+
+**Structure Decision**: Single Next.js app with frontend components. All changes are in `src/components/scorer/` and `src/app/game/[id]/scorer/`. Touch target improvements use Tailwind utility classes directly - no new CSS files needed.
+
+## Complexity Tracking
+
+> No constitution violations - table not needed.
+
+## Phase 0: Research
+
+### Research Questions
+
+1. **What is the current touch target sizing strategy?**
+   - Find all interactive elements in scorer components
+   - Document current sizes vs WCAG 2.5.5 requirements
+   - Identify Tailwind classes to modify
+
+2. **How does the scoring modal handle player selection?**
+   - Analyze `ScoringModal` component state flow
+   - Determine where to inject pre-selection logic
+   - Identify callback patterns for quick-repeat
+
+3. **What is the current mutation feedback implementation?**
+   - Check if there's existing loading state infrastructure
+   - Identify WebSocket subscription patterns
+   - Determine optimistic update behavior
+
+4. **What responsive breakpoints are in use?**
+   - Document `landscape:` vs `sm:/md:/lg:` breakpoints
+   - Identify where tables diverge from mobile landscape
+   - Find opportunities for tablet-specific improvements
+
+5. **What is the debounce strategy for button interactions?**
+   - Check for existing debounce patterns
+   - Identify where rapid-tap handling is needed
+   - Determine Framer Motion animation patterns
+
+## Phase 1: Design
+
+### Data Model
+
+This feature is primarily UI/UX focused with minimal new data entities:
+
+```markdown
+## UI State Entities
+
+### LastScorer (new)
+- playerId: string | null
+- team: 'home' | 'guest' | null
+- lastScoreType: 1 | 2 | 3 | null
+- expiresAt: 'substitution' | 'timeout' | 'period_end'
+```
+
+### Component Changes
+
+| Component | Change Type | Description |
+|-----------|-------------|-------------|
+| `page.tsx` | Modify | Add lastScorer state, pass to scoring modal |
+| `simple-scorer.tsx` | Modify | Increase button padding, fix touch targets |
+| `advanced-scorer.tsx` | Modify | Add quick-repeat button, increase touch targets |
+| `scoring-modal.tsx` | Modify | Support pre-selection from quick-repeat |
+| `game-log.tsx` | Modify | Increase icon sizes from 12px to 20px |
+| `quick-repeat-button.tsx` | NEW | Dedicated quick-action component |
+| `mutation-feedback.tsx` | NEW | Loading/success/error indicator |
+
+### Tailwind Class Changes
+
+| Element | Current | Target |
+|---------|---------|--------|
+| Period display | `text-[10px]` (portrait), `text-[8px]` (landscape) | `text-sm` (portrait), `text-xs` (landscape) |
+| Game log icons | `size={12}` | `size={20}` |
+| Connection indicator | `w-2 h-2` (portrait), `w-1.5 h-1.5` (landscape) | `w-3 h-3` (portrait), `w-2 h-2` (landscape) |
+| Miss buttons | `opacity-60` | `opacity-80` |
+| Foul buttons | `p-4` | `p-6` |
+
+### Touch Target Standards
+
+```typescript
+// New constants for consistent sizing
+const TOUCH_TARGETS = {
+  primary: 'min-h-[48px] min-w-[48px]', // WCAG 2.5.5 minimum
+  secondary: 'min-h-[44px] min-w-[44px]', // Secondary actions
+  icon: 'min-h-[32px] min-w-[32px] p-2', // Icon-only buttons
+} as const;
+
+const FONT_SIZES = {
+  periodPortrait: 'text-sm', // 14pt
+  periodLandscape: 'text-xs', // 12pt
+  clockPortrait: 'text-4xl', // 36pt
+  clockLandscape: 'text-3xl', // 28pt
+} as const;
+```
+
+## Quickstart
+
+```bash
+# 1. Start development server
+npm run dev
+
+# 2. Open scorer page
+open http://localhost:3000/game/{game-id}/scorer
+
+# 3. Test touch targets
+# - Open DevTools > Toggle device toolbar
+# - Test iPhone SE (375px), iPhone 14 Pro (393px), iPad Pro (1024px)
+# - Verify all buttons are tappable without precision
+
+# 4. Test quick-repeat feature
+# - Score for a player
+# - Verify "Score Again" button appears
+# - Tap button, verify modal opens with player pre-selected
+
+# 5. Test mutation feedback
+# - Score rapidly
+# - Verify visual feedback on button during sync
+# - Simulate network delay to see loading state
+
+# 6. Run tests
+npm run test -- --grep "scorer-ux"
+```
+
+## Implementation Priority
+
+1. **P1: Touch Target Fixes** (Low complexity, high impact)
+   - Increase period/clock text sizes
+   - Increase game log icon sizes
+   - Increase foul button padding
+   - Increase connection indicator size
+
+2. **P1: Quick-Repeat Shortcut** (Medium complexity, high impact)
+   - Add lastScorer state in page.tsx
+   - Create QuickRepeatButton component
+   - Modify scoring modal for pre-selection
+   - Clear state on lineup changes
+
+3. **P2: MutationFeedback** (Medium complexity, medium impact)
+   - Track in-flight mutations
+   - Add loading state to buttons
+   - Add success/error toasts
+
+4. **P2: Landscape Optimization** (Low complexity, medium impact)
+   - Add tablet breakpoint detection
+   - Collapse box-score button on narrow
+   - Increase miss button opacity
+
+5. **P3: Debounce Implementation** (Low complexity, low impact)
+   - Add debounce to scoring buttons
+   - Prevent rapid-tap duplicate mutations
+
+## Testing Strategy
+
+### Unit Tests
+- `quick-repeat-button.test.tsx`: Test visibility logic, state clearing
+- `mutation-feedback.test.tsx`: Test loading/success/error states
+- Touch target constants: Verify minimum sizes
+
+### E2E Tests
+- `scorer-ux.spec.ts`: Test touch targets on mobile/tablet viewports
+- Quick-repeat flow: Score → see button → tap → verify pre-selection
+- Mutation feedback: Rapid tap → verify single mutation
+
+### Accessibility Tests
+- WCAG 2.5.5 compliance: All interactive elements ≥ 44×44pt
+- Color contrast: Verify miss button opacity (70%)
+- Screen reader: Verify announcements for quick-repeat

--- a/specs/080-scorer-ux-improvements/quickstart.md
+++ b/specs/080-scorer-ux-improvements/quickstart.md
@@ -1,0 +1,162 @@
+# Quickstart: Scorer Page UX Improvements
+
+**Feature**: 080-scorer-ux-improvements  
+**Date**: 2026-03-17
+
+## Prerequisites
+
+- Node.js 18+ (check with `node --version`)
+- npm 9+ (check with `npm --version`)
+- Access to a running development server or test game
+
+## Quick Setup
+
+```bash
+# Clone and install (if needed)
+git checkout 080-scorer-ux-improvements
+npm install
+
+# Start development server
+npm run dev
+
+# Open scorer page (use an existing game ID or create new)
+open http://localhost:3000/game/{game-id}/scorer
+```
+
+## Testing Touch Targets
+
+### Manual Testing
+
+1. **Open DevTools** → Toggle device toolbar (Cmd+Shift+M)
+2. **Test viewports**:
+   - iPhone SE (375×667) - Smallest mobile portrait
+   - iPhone 14 Pro (393×852) - Common mobile portrait
+   - iPhone 14 Pro Landscape (852×393) - Mobile landscape
+   - iPad Pro (1024×768) - Tablet landscape
+3. **Verify each element**:
+   - Period display: Readable at arm's length
+   - Score buttons: Easy to tap without precision
+   - Foul buttons: Tapable with thumb
+   - Game log icons: Visible and tapable
+   - Connection indicator: Visible from distance
+
+### Automated Testing
+
+```bash
+# Run touch target tests
+npm run test -- --grep "touch-target"
+
+# Run E2E tests on mobile viewports
+npm run test:e2e -- scorer-ux.spec.ts
+```
+
+## Testing Quick-Repeat Feature
+
+### Setup
+
+1. Create or join a game
+2. Set roster with at least one player per team
+3. Start the game (status: live)
+
+### Test Flow
+
+```
+1. Tap +2 or +3 button
+2. Select a player (e.g., Player #23)
+3. Verify modal closes after scoring
+4. Look for "Score Again" button in the UI
+5. Tap "Score Again" button
+6. Verify modal opens with Player #23 pre-selected
+7. Tap +2 to complete the repeat score
+8. Verify only 2 taps needed (vs 3 for first score)
+```
+
+### Clear Conditions
+
+Test that the quick-repeat button disappears when:
+- A substitution is made (Subs modal used)
+- A timeout is called
+- The period changes
+- A different player scores
+
+## Testing Mutation Feedback
+
+### Setup
+
+1. Open DevTools → Network tab
+2. Enable "Slow 3G" throttling
+
+### Test Flow
+
+```
+1. Tap +2 button
+2. Watch for subtle pulse animation on button
+3. Verify score completes
+4. Look for brief success highlight (green flash)
+```
+
+### Error Scenario
+
+```
+1. Disable network in DevTools
+2. Tap +2 button
+3. Verify error toast appears after timeout
+4. Verify button returns to normal state
+```
+
+## Testing Landscape Optimization
+
+### Narrow Device (< 600pt)
+
+1. Set viewport to 568×320 (iPhone SE landscape)
+2. Verify Box Score button collapses or hides
+3. Verify scoring buttons remain tappable
+4. Verify miss buttons have ≥ 70% opacity
+
+### Tablet (≥ 600pt)
+
+1. Set viewport to 1024×768 (iPad Pro)
+2. Verify all buttons have ≥ 60×60pt touch targets
+3. Verify game log shows ≥ 8 items
+4. Verify text sizes are readable
+
+## Verification Checklist
+
+After implementation, verify:
+
+- [ ] Period display ≥ 12pt in landscape, ≥ 14pt in portrait
+- [ ] Clock display ≥ 28pt in landscape, ≥ 36pt in portrait
+- [ ] All score buttons ≥ 60×60pt touch target
+- [ ] Foul buttons ≥ 48×48pt touch target
+- [ ] Game log icons ≥ 20px visual size, ≥ 32×32pt touch target
+- [ ] Connection indicator ≥ 6×6pt
+- [ ] Miss buttons ≥ 70% opacity in landscape
+- [ ] Quick-repeat button appears after player scores
+- [ ] Quick-repeat button clears on substitutions/timeouts
+- [ ] Mutation feedback shows within 100ms
+- [ ] No double-scoring on rapid taps (debounce works)
+
+## Common Issues
+
+| Issue | Cause | Solution |
+|-------|-------|----------|
+| Quick-repeat not appearing | State not being set | Check `lastScorer` state in page.tsx |
+| Touch targets still small | Tailwind classes not applied | Verify `min-h-[48px]` classes |
+| No mutation feedback | Missing pending state | Check `pendingMutations` Set in React state |
+| Landscape layout broken | Breakpoint conflict | Verify `landscape:` and `md:` combinations |
+
+## Files Modified
+
+```
+src/app/game/[id]/scorer/page.tsx
+src/components/scorer/simple-scorer.tsx
+src/components/scorer/advanced-scorer.tsx
+src/components/scorer/scoring-modal.tsx
+src/components/scorer/game-log.tsx
+src/lib/constants/touch-targets.ts (new)
+src/components/scorer/quick-repeat-button.tsx (new)
+src/components/scorer/mutation-feedback.tsx (new)
+tests/components/scorer/quick-repeat-button.test.tsx (new)
+tests/components/scorer/mutation-feedback.test.tsx (new)
+tests/e2e/scorer-ux.spec.ts (new)
+```

--- a/specs/080-scorer-ux-improvements/research.md
+++ b/specs/080-scorer-ux-improvements/research.md
@@ -1,0 +1,201 @@
+# Research: Scorer Page UX Improvements
+
+**Feature**: 080-scorer-ux-improvements  
+**Date**: 2026-03-17
+
+## Research Questions
+
+### 1. Current Touch Target Sizing Strategy
+
+**Finding**: Touch targets are defined using Tailwind utility classes with inconsistent sizing across components.
+
+**Current Sizes**:
+
+| Element | Portrait | Landscape | Issue |
+|---------|----------|-----------|-------|
+| Score buttons | `p-6` (~100px) | Varied | Good |
+| Miss buttons | `p-4` (~80px) | `opacity-60` | Marginal, low visibility |
+| Foul buttons | `p-4` (~64px) | Same | Marginal (44pt min) |
+| Period display | `text-[10px]` | `text-[8px]` | Too small |
+| Clock | `text-4xl` | `text-3xl` | Good |
+| Connection indicator | `w-2 h-2` | `w-1.5 h-1.5` | Too small |
+| Game log icons | `size={12}` | Same | Too small |
+| Timer button | `h-20` | Full height | Good |
+
+**Recommendation**: Create consistent touch target constants using Tailwind's theme extension or inline utility classes. Focus on:
+- Increase `text-[10px]` and `text-[8px]` to `text-sm` and `text-xs`
+- Increase `size={12}` icons to `size={20}`
+- Increase `p-4` buttons to `p-6`
+
+### 2. Scoring Modal Player Selection Flow
+
+**Finding**: The `ScoringModal` component has a clear state flow that can be extended for pre-selection.
+
+**Current Flow**:
+```typescript
+// scoring-modal.tsx
+const [selectedTeam, setSelectedTeam] = useState<'home' | 'guest' | null>(scoringFor.side || null);
+
+// When scoringFor.side is provided, team is pre-selected
+// But player selection still requires explicit click
+```
+
+**Recommendation**: Extend `scoringFor` prop to include optional `playerId`:
+```typescript
+interface ScoringModalProps {
+  scoringFor: { points: number; isMiss?: boolean; side?: 'home' | 'guest'; playerId?: string };
+  // ...
+}
+```
+
+When `playerId` is provided, the modal should:
+1. Pre-select that player
+2. Highlight the selection
+3. Allow one-click confirmation or re-selection
+
+### 3. Mutation Feedback Implementation
+
+**Finding**: No explicit mutation feedback exists. The `useHasuraGame` hook uses CAS (compare-and-swap) with versioned updates but provides no visual feedback during mutations.
+
+**Current State**:
+- Scores update via `updateScore()` which calls `versionedUpdate()`
+- No loading state on buttons during mutation
+- WebSocket subscription pushes updates after server confirmation
+- Conflict detection shows a banner but only after failure
+
+**Recommendation**: Add mutation state tracking:
+```typescript
+// New state in page.tsx
+const [pendingMutations, setPendingMutations] = useState<Set<string>>(new Set());
+
+// Track mutation lifecycle
+const handleScoreWithFeedback = async (points: number, side?: 'home' | 'guest') => {
+  const mutationId = `score-${Date.now()}`;
+  setPendingMutations(prev => new Set(prev).add(mutationId));
+  
+  try {
+    await updateScore('home', points);
+    // Visual success feedback
+  } finally {
+    setPendingMutations(prev => {
+      const next = new Set(prev);
+      next.delete(mutationId);
+      return next;
+    });
+  }
+};
+```
+
+### 4. Responsive Breakpoints
+
+**Finding**: The scorer page uses a custom `landscape:` Tailwind variant rather than standard `sm:/md:/lg:` breakpoints.
+
+**Current Strategy**:
+```tsx
+// Portrait layout (default)
+<div className="flex flex-col flex-1 landscape:hidden">
+
+// Landscape layout (CSS media query)
+<div className="hidden landscape:grid grid-cols-[1fr_1.5fr_1fr]">
+```
+
+**Impact**: 
+- No distinction between mobile landscape and tablet landscape
+- Elements don't scale based on actual width, only orientation
+- Tablet users get same cramped layout as mobile landscape
+
+**Recommendation**: Add device-width breakpoints:
+```tsx
+// Mobile landscape
+<div className="hidden landscape:grid landscape:md:hidden">
+
+// Tablet and desktop landscape
+<div className="hidden landscape:md:grid">
+```
+
+### 5. Debounce Strategy
+
+**Finding**: No debounce exists on scoring buttons. Each click fires an immediate mutation.
+
+**Current Behavior**:
+- Rapid taps send multiple mutations
+- CAS will reject duplicates but still processes them
+- No client-side rate limiting
+
+**Recommendation**: Add debounce with leading edge:
+```typescript
+import { useCallback, useRef } from 'react';
+
+const useDebouncedScore = () => {
+  const lastScoreTime = useRef(0);
+  
+  const handleScore = useCallback((points: number, side?: 'home' | 'guest') => {
+    const now = Date.now();
+    if (now - lastScoreTime.current < 300) {
+      // Debounce: ignore clicks within 300ms
+      return;
+    }
+    lastScoreTime.current = now;
+    // Original score logic
+  }, []);
+  
+  return handleScore;
+};
+```
+
+**Alternative**: Use Framer Motion's `tap` event which has built-in debouncing.
+
+## Technology Decisions
+
+### Touch Target Implementation
+
+**Decision**: Use Tailwind inline classes for touch targets
+**Rationale**: 
+- Consistent with existing CSS strategy
+- No new build dependencies
+- Easy to adjust per-component
+- Can extract to theme later if needed
+
+**Alternatives Considered**:
+- CSS custom properties (more setup, same outcome)
+- New stylesheet (unnecessary complexity)
+
+### Quick-Repeat Button State
+
+**Decision**: React state in `page.tsx` with explicit clear triggers
+**Rationale**:
+- Simple, no Zustand store needed
+- State lives near where it's used
+- Easy to clear on substitutions/timeouts
+
+**Alternatives Considered**:
+- Zustand store (overkill for single feature)
+- URL state (not needed for transient UI state)
+
+### Mutation Feedback
+
+**Decision**: Local state tracking with `Set<string>` for pending mutations
+**Rationale**:
+- Lightweight, no additional infrastructure
+- Already have React state management in page
+- Can be extracted to hook if needed
+
+**Alternatives Considered**:
+- React Query mutations (adds dependency)
+- Zustand loading store (overkill)
+
+### Responsive Strategy
+
+**Decision**: Keep `landscape:` variant, add `md:` breakpoint for tablets
+**Rationale**:
+- Maintains backward compatibility
+- Adds tablet-specific improvements
+- Minimal code changes
+
+## Best Practices Identified
+
+1. **WCAG 2.5.5 Touch Target**: All interactive elements ≥ 44×44pt (WCAG Level AAA)
+2. **Mutation Feedback**: Visual confirmation within 100ms of user action
+3. **Debounce Pattern**: 300ms minimum between same-action triggers
+4. **Accessibility**: `type="button"` for all `<button>` elements (prevents form submission)
+5. **Framer Motion**: Use `animate` with `transition: { duration: 0.1 }` for quick feedback

--- a/specs/080-scorer-ux-improvements/spec.md
+++ b/specs/080-scorer-ux-improvements/spec.md
@@ -1,0 +1,152 @@
+# Feature Specification: Scorer Page UX Improvements
+
+**Feature Branch**: `080-scorer-ux-improvements`  
+**Created**: 2026-03-17  
+**Status**: Draft  
+**Input**: "Improve scorer page UI for responsive design across mobile portrait, mobile landscape, tablet, and PC with optimized touch targets, click efficiency, and legibility for fast-paced basketball scoring"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Fast Player Scoring (Priority: P1)
+
+As a basketball scorer using a mobile phone during an intense game, I need to record scores for the same player multiple times in quick succession without re-selecting the player each time, so that I can keep up with rapid gameplay and not miss any action.
+
+**Why this priority**: Basketball games have rapid scoring sequences where the same player often scores multiple baskets consecutively. Reducing the click count from 3 to 2 for repeat scorers directly impacts game accuracy and scorer stress during fast-paced moments.
+
+**Independent Test**: Can be fully tested by selecting a player, scoring for them, and then verifying that a shortcut to score again for the same player appears, reducing subsequent scores from 3 clicks to 2.
+
+**Acceptance Scenarios**:
+
+1. **Given** a player has just scored, **When** the scoring modal closes, **Then** a "Score Again for [Player]" quick-action button appears in the scoring interface (portrait and landscape)
+2. **Given** the quick-action button is visible, **When** tapped, **Then** the scoring modal opens with that player pre-selected, requiring only the point value to be chosen
+3. **Given** a different player is selected or the game state changes significantly (timeout, period end), **When** the scorer returns to the main interface, **Then** the quick-action button updates to reflect the current context or disappears if no recent scorer
+
+---
+
+### User Story 2 - Touch Target Visibility (Priority: P1)
+
+As a scorer using the app outdoors or in varying lighting conditions, I need all interactive elements to be clearly visible and large enough to tap reliably, so that I can operate the interface without looking twice or making errors.
+
+**Why this priority**: Touch targets that are too small or have insufficient contrast cause errors during fast gameplay. The period display, game log action icons, and connection indicator are currently below WCAG 2.5.5 minimum touch target recommendations.
+
+**Independent Test**: Can be fully tested by measuring touch target sizes and verifying all interactive elements meet minimum 48×48pt size requirements across all device layouts.
+
+**Acceptance Scenarios**:
+
+1. **Given** the scorer page in portrait mode, **When** displayed on any supported device, **Then** all primary scoring buttons (+2, +3, +1) have touch targets ≥ 60×60pt
+2. **Given** the scorer page in landscape mode, **When** displayed on any supported device, **Then** the period indicator has a touch target ≥ 48×48pt and text size ≥ 12pt
+3. **Given** the scorer page at any orientation, **When** displayed, **Then** game log action icons (edit, delete) have touch targets ≥ 32×32pt and visual size ≥ 20×20pt
+4. **Given** the scorer page in any mode, **When** the WebSocket connection status is displayed, **Then** the indicator has a minimum visual size of 6×6pt and is legible at arm's length
+
+---
+
+### User Story 3 - Period and Clock Accessibility (Priority: P2)
+
+As a scorer focusing on game action, I need the period number and clock display to be immediately readable at a glance without squinting or focusing, so that I can quickly verify game state while keeping my eyes on the court.
+
+**Why this priority**: Period and clock information is critical for game management decisions (timeouts, fouls management). The current small text sizes require focused attention away from the court.
+
+**Independent Test**: Can be fully tested by displaying the scorer page at all supported orientations and verifying period/clock text meets minimum legibility thresholds.
+
+**Acceptance Scenarios**:
+
+1. **Given** the scorer page in portrait mode, **When** displayed, **Then** the period display shows "P{N}" with text ≥ 14pt and is tappable to advance periods
+2. **Given** the scorer page in landscape mode, **When** displayed, **Then** the period display shows "P{N}" with text ≥ 12pt (increased from current 8pt)
+3. **Given** the clock display at any orientation, **When** the timer is running or stopped, **Then** the clock digits are ≥ 36pt in portrait and ≥ 28pt in landscape
+4. **Given** the period indicator, **When** tapped, **Then** the period advances with visual feedback confirming the action
+
+---
+
+### User Story 4 - Landscape Mode Optimization (Priority: P2)
+
+As a scorer using a tablet or phone in landscape mode, I need the scoring buttons, game log, and action controls to be proportionally sized so that all elements are comfortably tappable without hand strain or accidental mis-taps.
+
+**Why this priority**: Landscape mode is commonly used by tablet users and mobile users who prefer wider view. The current layout has overly compressed elements that reduce usability.
+
+**Independent Test**: Can be fully tested by displaying the scorer page in landscape on multiple device widths and measuring that all buttons maintain ≥ 44pt minimum touch targets even at narrow widths.
+
+**Acceptance Scenarios**:
+
+1. **Given** the scorer page in landscape mode on a 667pt-width device, **When** displayed, **Then** scoring button columns maintain ≥ 44pt width per button
+2. **Given** the scorer page in landscape mode, **When** displayed, **Then** the miss buttons (−2, −3, −1) have opacity ≥ 70% (increased from 60%) and padding ≥ 12pt
+3. **Given** the scorer page in landscape mode, **When** displayed, **Then** the game log shows at least 8 items with text size ≥ 10pt
+4. **Given** the scorer page in landscape mode on a narrow device (< 600pt), **When** displayed, **Then** the "Box Score" navigation button is collapsed or hidden to prioritize scoring controls
+
+---
+
+### User Story 5 - Real-Time Sync Feedback (Priority: P3)
+
+As a scorer experiencing network latency or connectivity issues, I need visual feedback when my scoring actions are in progress or have failed to sync, so that I can avoid double-scoring or missing events during connection problems.
+
+**Why this priority**: Scorers in gymnasiums may experience WiFi/cellular connectivity issues. Without feedback, they may tap multiple times or not realize events failed to sync.
+
+**Independent Test**: Can be fully tested by simulating network conditions and verifying visual feedback appears during mutation states.
+
+**Acceptance Scenarios**:
+
+1. **Given** a scorer taps a scoring button, **When** the mutation is in progress, **Then** the button briefly shows a loading state (subtle pulse, not blocking)
+2. **Given** a scoring mutation completes, **When** success, **Then** visual feedback confirms the score was recorded (brief highlight, haptic on mobile)
+3. **Given** a scoring mutation fails, **When** the error is detected, **Then** an error toast appears indicating the action failed and offering retry
+4. **Given** the WebSocket connection is lost, **When** displayed, **Then** the connection indicator turns red and a toast explains the scorer can continue scoring locally (optimistic updates)
+
+---
+
+### Edge Cases
+
+- What happens when a scorer rapidly taps the same button multiple times? Should debounce and only send one mutation, not queue multiple.
+- How does the interface handle orientation changes mid-action? Any open modal should adapt gracefully or maintain scroll position.
+- What happens when touch targets overlap on very narrow screens? Elements should collapse or stack rather than overlap.
+- How does the last-scored-player shortcut handle player substitutions? Should clear when lineup changes significantly.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST provide a "quick repeat" shortcut after a player scores, allowing the scorer to score again for the same player with fewer taps.
+- **FR-002**: System MUST display all interactive touch targets at minimum 44×44pt across all device orientations and sizes.
+- **FR-003**: System MUST display the period indicator with text ≥ 12pt in landscape mode and ≥ 14pt in portrait mode.
+- **FR-004**: System MUST display the game clock with digits ≥ 28pt in landscape mode and ≥ 36pt in portrait mode.
+- **FR-005**: System MUST provide visual feedback during scoring mutations (loading state on button, success confirmation).
+- **FR-006**: System MUST display the WebSocket connection status with a minimum visual indicator of 6×6pt.
+- **FR-007**: System MUST increase the opacity of "miss" buttons in landscape mode from 60% to ≥ 70% for better visibility.
+- **FR-008**: System MUST ensure all game log action icons (edit, delete) have touch targets ≥ 32×32pt.
+- **FR-009**: System MUST adapt the landscape layout for narrow devices (< 600pt width) by collapsing or hiding secondary navigation controls.
+- **FR-010**: System MUST clear the quick-repeat shortcut when lineup changes (substitutions) or a significant game event occurs (timeout, period end).
+- **FR-011**: System MUST debounce rapid consecutive taps on scoring buttons to prevent duplicate mutations.
+- **FR-012**: System MUST maintain scoring functionality during temporary connection loss using optimistic local updates with eventual sync.
+
+### Key Entities
+
+- **Quick-Action State**: Tracks the last-scoring-player context for the shortcut feature. Includes player ID, team, point type, expiration trigger events.
+- **Touch Target Configuration**: Theme/layout constants defining minimum sizes for various element types (primary action, secondary action, navigation).
+- **Mutation Feedback State**: Tracks in-flight mutations for visual feedback. Includes mutation ID, target element, status (pending, success, error).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Scorers can record a repeat score for the same player in 2 clicks (down from 3) after initial player selection.
+- **SC-002**: All interactive touch targets meet WCAG 2.5.5 minimum of 44×44pt across portrait mobile, landscape mobile, landscape tablet, and desktop views.
+- **SC-003**: Period indicator is readable at arm's length (≥ 12pt) in all orientations.
+- **SC-004**: Scoring mutations show visual feedback within 100ms of user action.
+- **SC-005**: Connection status indicator is visible from 2 meters away.
+- **SC-006**: Landscape mode on devices ≥ 600pt wide displays all primary scoring buttons with ≥ 60×60pt touch targets.
+- **SC-007**: Game log items are legible with text ≥ 10pt and action icons ≥ 20pt visual size.
+- **SC-008**: 90% of scorers can complete a scoring action within 3 seconds during repeated testing scenarios.
+- **SC-009**: Zero double-scoring events during rapid-tap testing (5 taps in 1 second).
+
+## Assumptions
+
+- Current Tailwind CSS infrastructure supports responsive design changes without major architectural changes.
+- Existing Framer Motion animations can be adjusted for new interaction feedback.
+- The scoring modal component can be extended to support pre-selection states.
+- WebSocket infrastructure already supports optimistic updates (mutation feedback is display layer only).
+- The app is tested primarily on mobile phones (portrait primary) and tablets (landscape primary), with desktop as secondary.
+
+## Out of Scope
+
+- Keyboard shortcuts for desktop users (can be addressed in a follow-up feature).
+- Persistent player stats sidebar for large screens (can be addressed in a follow-up feature).
+- Advanced gesture-based scoring (swipe to score, long-press for foul).
+- Voice-activated scoring.
+- Multi-game view for tournament managers.

--- a/specs/080-scorer-ux-improvements/tasks.md
+++ b/specs/080-scorer-ux-improvements/tasks.md
@@ -1,0 +1,285 @@
+# Tasks: Scorer Page UX Improvements
+
+**Input**: Design documents from `/specs/080-scorer-ux-improvements/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md
+
+**Tests**: Tests are included per constitution requirement V (Test Coverage for Business Logic).
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Single Next.js project**: `src/`, `tests/` at repository root
+- All changes are frontend-only in `src/components/scorer/` and `src/app/game/[id]/scorer/`
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create shared constants and types for touch targets and UI state
+
+- [x] T001 Create touch target constants file at src/lib/constants/touch-targets.ts
+- [x] T002 [P] Create LastScorerState type definition in src/lib/types/scorer-ui.ts
+- [x] T003 [P] Create MutationFeedbackState type definition in src/lib/types/scorer-ui.ts
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core UI state infrastructure that MUST be complete before user story implementation
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [x] T004 Add lastScorer state to scorer page in src/app/game/[id]/scorer/page.tsx
+- [x] T005 Add pendingMutations state to scorer page in src/app/game/[id]/scorer/page.tsx
+- [x] T006 Create QuickRepeatButton component in src/components/scorer/quick-repeat-button.tsx
+- [x] T007 [P] Create MutationFeedback component in src/components/scorer/mutation-feedback.tsx
+
+**Checkpoint**: Foundation ready - user story implementation can now begin in parallel
+
+---
+
+## Phase 3: User Story 1 - Fast Player Scoring (Priority: P1) 🎯 MVP
+
+**Goal**: Reduce clicks from 3 to 2 for repeat scoring by same player
+
+**Independent Test**: Score for a player, verify "Score Again" button appears, tap it, verify modal opens with player pre-selected
+
+### Tests for User Story 1
+
+- [ ] T008 [P] [US1] Create unit tests for QuickRepeatButton in tests/components/scorer/quick-repeat-button.test.tsx
+- [ ] T009 [P] [US1] Create E2E test for quick-repeat flow in tests/e2e/scorer-ux.spec.ts
+
+### Implementation for User Story 1
+
+- [ ] T010 [US1] Extend ScoringModalProps to accept preSelectedPlayerId in src/components/scorer/scoring-modal.tsx
+- [ ] T011 [US1] Add pre-selection logic to ScoringModal in src/components/scorer/scoring-modal.tsx
+- [ ] T012 [US1] Integrate QuickRepeatButton into portrait layout in src/app/game/[id]/scorer/page.tsx
+- [ ] T013 [US1] Integrate QuickRepeatButton into landscape layout in src/app/game/[id]/scorer/page.tsx
+- [ ] T014 [US1] Add clear triggers for lastScorer state (substitution, timeout, period end) in src/app/game/[id]/scorer/page.tsx
+- [ ] T015 [US1] Add visual feedback when quick-repeat button is tapped in src/components/scorer/quick-repeat-button.tsx
+
+**Checkpoint**: User Story 1 complete - quick-repeat feature fully functional and testable
+
+---
+
+## Phase 4: User Story 2 - Touch Target Visibility (Priority: P1)
+
+**Goal**: All interactive elements meet WCAG 2.5.5 minimum 44×44pt touch targets
+
+**Independent Test**: Measure touch target sizes on mobile/tablet viewports, verify all meet minimums
+
+### Tests for User Story 2
+
+- [ ] T016 [P] [US2] Add touch target size tests to tests/e2e/scorer-ux.spec.ts
+
+### Implementation for User Story 2
+
+- [ ] T017 [P] [US2] Increase foul button padding from p-4 to p-6 in src/components/scorer/simple-scorer.tsx
+- [ ] T018 [P] [US2] Increase game log action icons from size={12} to size={20} in src/components/scorer/game-log.tsx
+- [ ] T019 [P] [US2] Add min-h-[32px] min-w-[32px] to game log action buttons in src/components/scorer/game-log.tsx
+- [ ] T020 [P] [US2] Increase connection indicator from w-2 h-2 to w-3 h-3 (portrait) in src/app/game/[id]/scorer/page.tsx
+- [ ] T021 [P] [US2] Increase connection indicator from w-1.5 h-1.5 to w-2 h-2 (landscape) in src/app/game/[id]/scorer/page.tsx
+- [ ] T022 [US2] Add min-w-[48px] min-h-[48px] to period display button in src/app/game/[id]/scorer/page.tsx
+
+**Checkpoint**: User Story 2 complete - all touch targets meet WCAG 2.5.5
+
+---
+
+## Phase 5: User Story 3 - Period and Clock Accessibility (Priority: P2)
+
+**Goal**: Period and clock displays are immediately readable at a glance
+
+**Independent Test**: Display scorer page at all orientations, verify text sizes meet minimums
+
+### Tests for User Story 3
+
+- [ ] T023 [P] [US3] Add period/clock legibility tests to tests/e2e/scorer-ux.spec.ts
+
+### Implementation for User Story 3
+
+- [ ] T024 [P] [US3] Increase period text from text-[10px] to text-sm (portrait) in src/app/game/[id]/scorer/page.tsx
+- [ ] T025 [P] [US3] Increase period text from text-[8px] to text-xs (landscape) in src/app/game/[id]/scorer/page.tsx
+- [ ] T026 [US3] Add visual feedback on period advance (brief highlight) in src/app/game/[id]/scorer/page.tsx
+
+**Checkpoint**: User Story 3 complete - period and clock are legible at arm's length
+
+---
+
+## Phase 6: User Story 4 - Landscape Mode Optimization (Priority: P2)
+
+**Goal**: Landscape layout is proportionally sized for comfortable tapping
+
+**Independent Test**: Display on narrow landscape (< 600pt), verify all buttons are tappable
+
+### Tests for User Story 4
+
+- [ ] T027 [P] [US4] Add landscape layout tests for narrow devices to tests/e2e/scorer-ux.spec.ts
+
+### Implementation for User Story 4
+
+- [ ] T028 [P] [US4] Increase miss button opacity from opacity-60 to opacity-80 in src/app/game/[id]/scorer/page.tsx
+- [ ] T029 [P] [US4] Add p-3 padding to miss buttons in landscape layout in src/app/game/[id]/scorer/page.tsx
+- [ ] T030 [US4] Add conditional hiding of Box Score button on narrow landscape (< 600pt) in src/app/game/[id]/scorer/page.tsx
+- [ ] T031 [US4] Increase game log limit from 10 to 12 items in landscape mode in src/app/game/[id]/scorer/page.tsx
+
+**Checkpoint**: User Story 4 complete - landscape mode optimized for all device widths
+
+---
+
+## Phase 7: User Story 5 - Real-Time Sync Feedback (Priority: P3)
+
+**Goal**: Scorers see visual feedback during scoring mutations
+
+**Independent Test**: Simulate network delay, verify loading state appears on buttons
+
+### Tests for User Story 5
+
+- [ ] T032 [P] [US5] Create unit tests for MutationFeedback in tests/components/scorer/mutation-feedback.test.tsx
+- [ ] T033 [P] [US5] Add mutation feedback E2E tests to tests/e2e/scorer-ux.spec.ts
+
+### Implementation for User Story 5
+
+- [ ] T034 [US5] Add mutation tracking to handleScore function in src/app/game/[id]/scorer/page.tsx
+- [ ] T035 [US5] Add loading pulse animation to scoring buttons during mutation in src/app/game/[id]/scorer/page.tsx
+- [ ] T036 [US5] Add success highlight animation after mutation completes in src/app/game/[id]/scorer/page.tsx
+- [ ] T037 [US5] Add error toast for failed mutations in src/app/game/[id]/scorer/page.tsx
+- [ ] T038 [US5] Add debounce (300ms) to scoring buttons to prevent rapid-tap duplicates in src/app/game/[id]/scorer/page.tsx
+
+**Checkpoint**: User Story 5 complete - mutation feedback visible on all scoring actions
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final improvements and validation
+
+- [ ] T039 [P] Run all unit tests and verify passing: npm run test
+- [ ] T040 [P] Run E2E tests on mobile viewport: npm run test:e2e -- scorer-ux.spec.ts
+- [ ] T041 Run quickstart.md validation scenarios
+- [ ] T042 [P] Update AGENTS.md with new components and patterns
+- [ ] T043 Final accessibility audit: verify all WCAG 2.5.5 touch targets
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - BLOCKS all user stories
+- **User Stories (Phase 3-7)**: All depend on Foundational phase completion
+  - US1 and US2 are both P1 - can proceed in parallel
+  - US3 and US4 are both P2 - can proceed in parallel
+  - US5 is P3 - can proceed after P1/P2 stories
+- **Polish (Phase 8)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Foundational - No dependencies on other stories
+- **User Story 2 (P1)**: Can start after Foundational - No dependencies on other stories
+- **User Story 3 (P2)**: Can start after Foundational - No dependencies on other stories
+- **User Story 4 (P2)**: Can start after Foundational - No dependencies on other stories
+- **User Story 5 (P3)**: Can start after Foundational - No dependencies on other stories
+
+### Within Each User Story
+
+- Tests MUST be written and FAIL before implementation
+- Component creation before integration
+- Integration before state management
+- Story complete before moving to next priority
+
+### Parallel Opportunities
+
+- All Setup tasks (T001-T003) can run in parallel
+- T006 and T007 can run in parallel (different files)
+- All tests within a user story marked [P] can run in parallel
+- All touch target fixes (T017-T021) can run in parallel
+- US1 and US2 can be worked on in parallel (both P1)
+- US3 and US4 can be worked on in parallel (both P2)
+
+---
+
+## Parallel Example: User Story 1 + User Story 2 (Both P1)
+
+```bash
+# Launch tests for both stories together:
+Task: "T008 [P] [US1] Create unit tests for QuickRepeatButton"
+Task: "T009 [P] [US1] Create E2E test for quick-repeat flow"
+Task: "T016 [P] [US2] Add touch target size tests"
+
+# Launch touch target fixes in parallel:
+Task: "T017 [P] [US2] Increase foul button padding"
+Task: "T018 [P] [US2] Increase game log action icons"
+Task: "T019 [P] [US2] Add min-h/min-w to game log buttons"
+Task: "T020 [P] [US2] Increase connection indicator (portrait)"
+Task: "T021 [P] [US2] Increase connection indicator (landscape)"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 + User Story 2)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational (CRITICAL - blocks all stories)
+3. Complete Phase 3: User Story 1 (Quick-Repeat)
+4. Complete Phase 4: User Story 2 (Touch Targets)
+5. **STOP and VALIDATE**: Test US1 and US2 independently
+6. Deploy/demo if ready - MVP delivered!
+
+### Incremental Delivery
+
+1. Complete Setup + Foundational → Foundation ready
+2. Add User Story 1 + User Story 2 → Test independently → Deploy/Demo (MVP!)
+3. Add User Story 3 + User Story 4 → Test independently → Deploy/Demo
+4. Add User Story 5 → Test independently → Deploy/Demo
+5. Each story adds value without breaking previous stories
+
+### Parallel Team Strategy
+
+With multiple developers:
+
+1. Team completes Setup + Foundational together
+2. Once Foundational is done:
+   - Developer A: User Story 1 (Quick-Repeat)
+   - Developer B: User Story 2 (Touch Targets)
+   - Developer C: User Story 3 (Period/Clock)
+3. Stories complete and integrate independently
+
+---
+
+## Summary
+
+| Phase | Tasks | Parallel | Story |
+|-------|-------|----------|-------|
+| Setup | 3 | 2 | - |
+| Foundational | 4 | 1 | - |
+| User Story 1 | 8 | 2 | US1 |
+| User Story 2 | 7 | 5 | US2 |
+| User Story 3 | 4 | 1 | US3 |
+| User Story 4 | 5 | 2 | US4 |
+| User Story 5 | 7 | 2 | US5 |
+| Polish | 5 | 3 | - |
+| **Total** | **43** | **18** | - |
+
+**MVP Scope**: Phase 1-4 (Setup + Foundational + US1 + US2) = 22 tasks
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Each user story is independently completable and testable
+- Verify tests fail before implementing
+- Commit after each task or logical group
+- Stop at any checkpoint to validate story independently
+- Avoid: vague tasks, same file conflicts, cross-story dependencies that break independence

--- a/src/app/game/[id]/scorer/page.tsx
+++ b/src/app/game/[id]/scorer/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { flushSync } from 'react-dom';
 import { useParams, useRouter } from 'next/navigation';
 import { useHasuraGame } from '@/hooks/use-hasura-game';
@@ -23,6 +23,8 @@ import { GameLog, type GameEvent } from '@/components/scorer/game-log';
 import { ScorerManager } from '@/components/scorer/scorer-manager';
 import { GameSettingsModal } from '@/components/scorer/game-settings-modal';
 import { RecalcToast } from '@/components/scorer/recalc-toast';
+import { MutationFeedback } from '@/components/scorer/mutation-feedback';
+import { ANIMATION_DURATIONS } from '@/lib/constants/touch-targets';
 import QRCode from 'react-qr-code';
 
 function cn(...inputs: ClassValue[]) {
@@ -124,7 +126,7 @@ export default function ScorerPage() {
 
     const [game, setGame] = useState<Game | null>(null);
     const [loading, setLoading] = useState(true);
-    const [scoringFor, setScoringFor] = useState<{ points: number, side?: 'home' | 'guest', isMiss?: boolean } | null>(null);
+    const [scoringFor, setScoringFor] = useState<{ points: number, side?: 'home' | 'guest', isMiss?: boolean, preSelectedPlayerId?: string } | null>(null);
     const [isSubsOpen, setIsSubsOpen] = useState(false);
     const [isTimeEditing, setIsTimeEditing] = useState(false);
     const [tempTime, setTempTime] = useState<{ min: string, sec: string }>({ min: '10', sec: '00' });
@@ -142,6 +144,12 @@ export default function ScorerPage() {
     const [scorers, setScorers] = useState<Scorer[]>([]);
     const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
     const [isDeleting, setIsDeleting] = useState(false);
+    
+    const [mutationPending, setMutationPending] = useState(false);
+    const [mutationSuccess, setMutationSuccess] = useState(false);
+    const [mutationError, setMutationError] = useState<string | null>(null);
+    
+    const lastScoreTimeRef = useRef<number>(0);
 
     useEffect(() => {
         fetch(`/api/games/${id}`)
@@ -161,6 +169,15 @@ export default function ScorerPage() {
         const interval = setInterval(updatePresence, 30_000);
         return () => clearInterval(interval);
     }, [updatePresence]);
+
+    useEffect(() => {
+        if (!mutationSuccess && !mutationError) return;
+        const timer = setTimeout(() => {
+            setMutationSuccess(false);
+            setMutationError(null);
+        }, 2000);
+        return () => clearTimeout(timer);
+    }, [mutationSuccess, mutationError]);
 
     // Sync Hasura subscription data into local game state
     useEffect(() => {
@@ -370,6 +387,14 @@ export default function ScorerPage() {
 
     const handlePlayerScore = (rosterEntryId: string) => {
         if (!scoringFor || !game) return;
+        
+        // Debounce: prevent rapid duplicate scoring
+        const now = Date.now();
+        if (now - lastScoreTimeRef.current < ANIMATION_DURATIONS.debounceWindow) {
+            setScoringFor(null);
+            return;
+        }
+        lastScoreTimeRef.current = now;
 
         const player = game.rosters.find(r => r.id === rosterEntryId);
         if (!player) return;
@@ -397,9 +422,17 @@ export default function ScorerPage() {
             ? { homeScore: game.homeScore + scoringFor.points }
             : { guestScore: game.guestScore + scoringFor.points };
 
+        setMutationPending(true);
+        
         updateGame({
             ...scoreUpdate,
             rosters: updatedRosters
+        }).then(() => {
+            setMutationPending(false);
+            setMutationSuccess(true);
+        }).catch((err) => {
+            setMutationPending(false);
+            setMutationError(err instanceof Error ? err.message : 'Failed to save score');
         });
 
         addEvent({
@@ -463,6 +496,7 @@ export default function ScorerPage() {
 
     const handleTimeout = (side?: 'home' | 'guest') => {
         if (!game) return;
+        
         if (!side) {
             setIsTimeoutOpen(true);
             return;
@@ -495,6 +529,7 @@ export default function ScorerPage() {
 
     const nextPeriod = async () => {
         if (!game) return;
+        
         const ok = await advancePeriod();
         if (!ok) return;
         addEvent({
@@ -716,6 +751,12 @@ export default function ScorerPage() {
             )}
             {/* Recalculation Toast */}
             <RecalcToast result={recalcToast} onDismiss={dismissRecalcToast} />
+            <MutationFeedback
+                isPending={mutationPending}
+                isSuccess={mutationSuccess}
+                isError={!!mutationError}
+                errorMessage={mutationError || undefined}
+            />
             {/* Top Header - THE DISPLAY */}
             <div className="bg-black/40 border-b border-border p-2 landscape:p-1 flex items-center justify-between shrink-0">
                 <div className="flex items-center gap-1">
@@ -734,7 +775,7 @@ export default function ScorerPage() {
                 <div className="flex items-center gap-4 landscape:gap-8">
                     {/* Home Score (Landscape only) */}
                     <div className="hidden landscape:flex flex-col items-center">
-                        <div className="text-[8px] font-black uppercase text-orange-500/60 leading-none mb-1">{game.homeTeamName}</div>
+                        <div className="text-[10px] font-black uppercase text-orange-500/80 leading-none mb-0.5">{game.homeTeamName}</div>
                         <div className="text-3xl font-black font-mono leading-none">{game.homeScore}</div>
                     </div>
 
@@ -743,9 +784,9 @@ export default function ScorerPage() {
                             <button
                                 data-testid="period-display"
                                 onClick={nextPeriod}
-                                className="text-[10px] landscape:text-[8px] uppercase tracking-widest text-slate-500 font-bold flex items-center gap-1 hover:text-white transition-colors"
+                                className="min-w-[44px] min-h-[44px] text-sm landscape:text-xs uppercase tracking-widest text-slate-500 font-bold flex items-center gap-1 hover:text-white transition-colors"
                             >
-                                <div className={cn("w-2 h-2 landscape:w-1.5 landscape:h-1.5 rounded-full", isConnected ? "bg-green-500" : "bg-red-500")} />
+                                <div className={cn("w-3 h-3 landscape:w-2 landscape:h-2 rounded-full", isConnected ? "bg-green-500" : "bg-red-500")} />
                                 P{game.currentPeriod}
                             </button>
                             {/* Visibility Badge */}
@@ -911,54 +952,54 @@ export default function ScorerPage() {
                 <div className="hidden landscape:grid grid-cols-[1fr_1.5fr_1fr] flex-1 overflow-hidden p-2 gap-2">
                     {/* LEFT THIRD: SCORING */}
                     <div className="grid grid-rows-3 gap-2 h-full">
-                        <div className="grid grid-cols-[1fr_0.6fr] gap-2">
+                        <div className="grid grid-cols-2 gap-2">
                             <button
                                 onClick={() => handleScore(3)}
-                                className="bg-orange-600/10 border border-orange-500/20 rounded-2xl flex flex-col items-center justify-center hover:bg-orange-600/20 active:scale-95 transition-all group"
+                                className="bg-orange-600/10 border border-orange-500/20 rounded-lg flex flex-col items-center justify-center hover:bg-orange-600/20 active:scale-95 transition-all group"
                             >
-                                <span className="text-4xl font-black text-orange-500 group-hover:scale-110 transition-transform">+3</span>
-                                <span className="text-[8px] uppercase font-black tracking-[0.2em] text-orange-500/50">Three Pointer</span>
+                                <span className="text-4xl landscape:lg:text-5xl font-black text-orange-500 group-hover:scale-110 transition-transform">+3</span>
+                                <span className="text-[10px] landscape:lg:text-sm uppercase font-bold tracking-wider text-orange-500/70">3PT</span>
                             </button>
                             <button
                                 onClick={() => handleScore(3, undefined, true)}
-                                className="bg-input border border-border rounded-2xl flex flex-col items-center justify-center hover:bg-card active:scale-95 transition-all group opacity-60 hover:opacity-100"
+                                className="bg-input border border-border rounded-lg flex flex-col items-center justify-center hover:bg-card active:scale-95 transition-all group opacity-80 hover:opacity-100"
                             >
-                                <span className="text-2xl font-black text-slate-500 group-hover:scale-110 transition-transform">-3</span>
-                                <span className="text-[7px] uppercase font-black tracking-widest text-slate-600">Miss</span>
+                                <span className="text-2xl landscape:lg:text-3xl font-black text-slate-500 group-hover:scale-110 transition-transform">-3</span>
+                                <span className="text-[10px] landscape:lg:text-sm uppercase font-bold tracking-wider text-slate-500">MISS</span>
                             </button>
                         </div>
 
-                        <div className="grid grid-cols-[1fr_0.6fr] gap-2">
+                        <div className="grid grid-cols-2 gap-2">
                             <button
                                 onClick={() => handleScore(2)}
-                                className="bg-input border border-border rounded-2xl flex flex-col items-center justify-center hover:bg-card active:scale-95 transition-all group"
+                                className="bg-input border border-border rounded-lg flex flex-col items-center justify-center hover:bg-card active:scale-95 transition-all group"
                             >
-                                <span className="text-4xl font-black text-slate-200 group-hover:scale-110 transition-transform">+2</span>
-                                <span className="text-[8px] uppercase font-black tracking-[0.2em] text-slate-500">Field Goal</span>
+                                <span className="text-4xl landscape:lg:text-5xl font-black text-slate-200 group-hover:scale-110 transition-transform">+2</span>
+                                <span className="text-[10px] landscape:lg:text-sm uppercase font-bold tracking-wider text-slate-400">FG</span>
                             </button>
                             <button
                                 onClick={() => handleScore(2, undefined, true)}
-                                className="bg-input border border-border rounded-2xl flex flex-col items-center justify-center hover:bg-card active:scale-95 transition-all group opacity-60 hover:opacity-100"
+                                className="bg-input border border-border rounded-lg flex flex-col items-center justify-center hover:bg-card active:scale-95 transition-all group opacity-80 hover:opacity-100"
                             >
-                                <span className="text-2xl font-black text-slate-500 group-hover:scale-110 transition-transform">-2</span>
-                                <span className="text-[7px] uppercase font-black tracking-widest text-slate-600">Miss</span>
+                                <span className="text-2xl landscape:lg:text-3xl font-black text-slate-500 group-hover:scale-110 transition-transform">-2</span>
+                                <span className="text-[10px] landscape:lg:text-sm uppercase font-bold tracking-wider text-slate-500">MISS</span>
                             </button>
                         </div>
 
-                        <div className="grid grid-cols-[1fr_0.6fr] gap-2">
+                        <div className="grid grid-cols-2 gap-2">
                             <button
                                 onClick={() => handleScore(1)}
-                                className="bg-input/50 border border-border rounded-2xl flex flex-col items-center justify-center hover:bg-card active:scale-95 transition-all group"
+                                className="bg-input/50 border border-border rounded-lg flex flex-col items-center justify-center hover:bg-card active:scale-95 transition-all group"
                             >
-                                <span className="text-3xl font-black text-slate-400 group-hover:scale-110 transition-transform">+1</span>
-                                <span className="text-[8px] uppercase font-black tracking-[0.2em] text-slate-600">Free Throw</span>
+                                <span className="text-3xl landscape:lg:text-4xl font-black text-slate-400 group-hover:scale-110 transition-transform">+1</span>
+                                <span className="text-[10px] landscape:lg:text-sm uppercase font-bold tracking-wider text-slate-500">FT</span>
                             </button>
                             <button
                                 onClick={() => handleScore(1, undefined, true)}
-                                className="bg-input border border-border rounded-2xl flex flex-col items-center justify-center hover:bg-card active:scale-95 transition-all group opacity-60 hover:opacity-100"
+                                className="bg-input border border-border rounded-lg flex flex-col items-center justify-center hover:bg-card active:scale-95 transition-all group opacity-80 hover:opacity-100"
                             >
-                                <span className="text-2xl font-black text-slate-500 group-hover:scale-110 transition-transform">-1</span>
-                                <span className="text-[7px] uppercase font-black tracking-widest text-slate-600">Miss</span>
+                                <span className="text-2xl landscape:lg:text-3xl font-black text-slate-500 group-hover:scale-110 transition-transform">-1</span>
+                                <span className="text-[10px] landscape:lg:text-sm uppercase font-bold tracking-wider text-slate-500">MISS</span>
                             </button>
                         </div>
                     </div>
@@ -968,7 +1009,7 @@ export default function ScorerPage() {
                         <div className="flex-1 overflow-y-auto custom-scrollbar p-1">
                             <GameLog
                                 events={events}
-                                limit={10}
+                                limit={12}
                                 onHeaderClick={() => router.push(`/game/${id}/scorer/log`)}
                                 onDelete={deleteEvent}
                                 onEdit={(id) => setEditingEvent(events.find(e => e.id === id) || null)}
@@ -982,17 +1023,17 @@ export default function ScorerPage() {
                         <div className="grid grid-cols-2 gap-2 flex-1">
                             <button
                                 onClick={() => handleFoul('home')}
-                                className="bg-red-950/20 border border-red-500/20 rounded-xl flex flex-col items-center justify-center hover:bg-red-900/40 active:scale-95 transition-all"
+                                className="bg-red-950/20 border border-red-500/20 rounded-lg flex flex-col items-center justify-center hover:bg-red-900/40 active:scale-95 transition-all"
                             >
-                                <span className="text-[9px] font-black uppercase text-red-500">Foul</span>
-                                <div className="text-xs font-mono font-black text-red-400">{game.homeFouls}</div>
+                                <span className="text-[10px] landscape:text-xs landscape:lg:text-base font-bold uppercase text-red-500">FOUL</span>
+                                <div className="text-lg landscape:lg:text-2xl font-mono font-black text-red-400">{game.homeFouls}</div>
                             </button>
                             <button
                                 onClick={() => handleFoul('guest')}
-                                className="bg-input border border-border rounded-xl flex flex-col items-center justify-center hover:bg-card active:scale-95 transition-all"
+                                className="bg-input border border-border rounded-lg flex flex-col items-center justify-center hover:bg-card active:scale-95 transition-all"
                             >
-                                <span className="text-[9px] font-black uppercase text-slate-500 text-center leading-tight px-1">Foul</span>
-                                <div className="text-xs font-mono font-black text-slate-300">{game.guestFouls}</div>
+                                <span className="text-[10px] landscape:text-xs landscape:lg:text-base font-bold uppercase text-slate-400">FOUL</span>
+                                <div className="text-lg landscape:lg:text-2xl font-mono font-black text-slate-300">{game.guestFouls}</div>
                             </button>
                         </div>
 
@@ -1000,21 +1041,21 @@ export default function ScorerPage() {
                         <div className="grid grid-cols-2 gap-2 flex-1">
                             <button
                                 onClick={handleSub}
-                                className="bg-input border border-border rounded-xl flex flex-col items-center justify-center hover:bg-card active:scale-95 transition-all"
+                                className="bg-input border border-border rounded-lg flex flex-col items-center justify-center hover:bg-card active:scale-95 transition-all"
                             >
-                                <Users size={14} className="text-slate-500 mb-0.5" />
-                                <span className="text-[8px] font-black uppercase tracking-widest text-slate-600">Subs</span>
+                                <Users size={16} className="landscape:lg:size-5 text-slate-400 mb-0.5" />
+                                <span className="text-[10px] landscape:text-xs landscape:lg:text-base font-bold uppercase tracking-wide text-slate-400">SUBS</span>
                             </button>
                             <button
                                 onClick={() => handleTimeout()}
-                                className="bg-input border border-border rounded-xl flex flex-col items-center justify-center hover:bg-card active:scale-95 transition-all"
+                                className="bg-input border border-border rounded-lg flex flex-col items-center justify-center hover:bg-card active:scale-95 transition-all"
                             >
                                 <div className="flex gap-0.5 mb-1">
                                     {Array.from({ length: game.totalTimeouts }).map((_, i) => (
                                         <div key={i} className={cn("w-2 h-0.5 rounded-full", i < game.homeTimeouts ? "bg-orange-500" : "bg-muted")} />
                                     ))}
                                 </div>
-                                <span className="text-[8px] font-black uppercase tracking-widest text-slate-600">TO</span>
+                                <span className="text-[10px] landscape:text-xs landscape:lg:text-base font-bold uppercase tracking-wide text-slate-400">TIMEOUT</span>
                             </button>
                         </div>
 
@@ -1022,21 +1063,21 @@ export default function ScorerPage() {
                         <button
                             onClick={toggleTimer}
                             className={cn(
-                                "flex-1 rounded-2xl flex flex-col items-center justify-center transition-all active:scale-95 shadow-xl",
+                                "flex-1 rounded-lg flex flex-col items-center justify-center transition-all active:scale-95 shadow-xl",
                                 isTimerRunning ? "bg-red-600 shadow-red-900/20" : "bg-emerald-600 shadow-emerald-900/20"
                             )}
                         >
-                            <Clock size={24} className={cn("text-white mb-1", isTimerRunning && "animate-pulse")} fill="currentColor" />
-                            <span className="text-[10px] font-black tracking-widest uppercase text-white">{isTimerRunning ? 'PAUSE' : 'RESUME'}</span>
+                            <Clock size={24} className={cn("text-white mb-1 landscape:lg:size-8", isTimerRunning && "animate-pulse")} fill="currentColor" />
+                            <span className="text-sm landscape:lg:text-base font-bold tracking-wide uppercase text-white">{isTimerRunning ? 'PAUSE' : 'RESUME'}</span>
                         </button>
 
                         {/* Box Score Button */}
                         <button
                             onClick={() => router.push(`/game/${id}/box-score`)}
-                            className="flex-1 rounded-xl flex flex-col items-center justify-center bg-input border border-border hover:bg-card transition-all active:scale-95"
+                            className="flex-1 rounded-lg flex-col items-center justify-center bg-input border border-border hover:bg-card transition-all active:scale-95 landscape:min-h-[500px]:flex hidden"
                         >
-                            <Table size={16} className="text-slate-400 mb-0.5" />
-                            <span className="text-[8px] font-black tracking-widest uppercase text-slate-500">Box Score</span>
+                            <Table size={16} className="landscape:lg:size-5 text-slate-400 mb-0.5" />
+                            <span className="text-[10px] landscape:text-xs landscape:lg:text-base font-bold uppercase tracking-wide text-slate-400">BOX SCORE</span>
                         </button>
                     </div>
                 </div>
@@ -1123,8 +1164,8 @@ export default function ScorerPage() {
                             }
                         }}
                     />
-                )}
-            </AnimatePresence>
+)}
+                </AnimatePresence>
 
             {/* Event Edit Modal */}
             <AnimatePresence>

--- a/src/components/scorer/game-log.tsx
+++ b/src/components/scorer/game-log.tsx
@@ -177,9 +177,9 @@ export function GameLog({ events, onDelete, onEdit, limit, onHeaderClick, hideHe
                                             setPendingDeleteId(event.id);
                                             setExpandedId(event.id);
                                         }}
-                                        className="ml-1 p-1 text-slate-700 hover:text-red-500 transition-colors rounded flex-shrink-0"
+                                        className="ml-1 p-1 min-h-[32px] min-w-[32px] text-slate-700 hover:text-red-500 transition-colors rounded flex-shrink-0 flex items-center justify-center"
                                     >
-                                        <Trash2 size={12} />
+                                        <Trash2 size={20} />
                                     </button>
                                 )}
                             </div>

--- a/src/components/scorer/mutation-feedback.tsx
+++ b/src/components/scorer/mutation-feedback.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { motion, AnimatePresence } from 'framer-motion';
+import { Loader2, Check, AlertCircle } from 'lucide-react';
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+function cn(...inputs: ClassValue[]) {
+    return twMerge(clsx(inputs));
+}
+
+interface MutationFeedbackProps {
+    isPending: boolean;
+    isSuccess: boolean;
+    isError: boolean;
+    errorMessage?: string;
+}
+
+export function MutationFeedback({ isPending, isSuccess, isError, errorMessage }: MutationFeedbackProps) {
+    return (
+        <AnimatePresence>
+            {isPending && (
+                <motion.div
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                    className="fixed top-4 right-4 z-50 bg-blue-500/90 text-white px-3 py-2 rounded-lg shadow-lg flex items-center gap-2"
+                >
+                    <Loader2 size={16} className="animate-spin" />
+                    <span className="text-sm font-medium">Saving...</span>
+                </motion.div>
+            )}
+            {isSuccess && (
+                <motion.div
+                    initial={{ opacity: 0, scale: 0.9 }}
+                    animate={{ opacity: 1, scale: 1 }}
+                    exit={{ opacity: 0, scale: 0.9 }}
+                    transition={{ duration: 0.2 }}
+                    className="fixed top-4 right-4 z-50 bg-green-500/90 text-white px-3 py-2 rounded-lg shadow-lg flex items-center gap-2"
+                >
+                    <Check size={16} />
+                    <span className="text-sm font-medium">Saved</span>
+                </motion.div>
+            )}
+            {isError && (
+                <motion.div
+                    initial={{ opacity: 0, scale: 0.9 }}
+                    animate={{ opacity: 1, scale: 1 }}
+                    exit={{ opacity: 0, scale: 0.9 }}
+                    transition={{ duration: 0.2 }}
+                    className="fixed top-4 right-4 z-50 bg-red-500/90 text-white px-4 py-3 rounded-lg shadow-lg"
+                >
+                    <div className="flex items-center gap-2">
+                        <AlertCircle size={16} />
+                        <span className="text-sm font-medium">{errorMessage || 'Failed to save'}</span>
+                    </div>
+                </motion.div>
+            )}
+        </AnimatePresence>
+    );
+}
+
+export function useMutationFeedback() {
+    return {
+        getPendingClasses: (isPending: boolean) =>
+            isPending ? 'animate-pulse opacity-70' : '',
+        
+        getSuccessClasses: (isSuccess: boolean) =>
+            isSuccess ? 'ring-2 ring-green-500 ring-offset-2 ring-offset-background' : '',
+    };
+}

--- a/src/components/scorer/quick-repeat-button.tsx
+++ b/src/components/scorer/quick-repeat-button.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { clsx, type ClassValue } from 'clsx';
+import { motion, AnimatePresence } from 'framer-motion';
+import { Repeat } from 'lucide-react';
+import { twMerge } from 'tailwind-merge';
+
+import type { LastScorerState } from '@/lib/types/scorer-ui';
+
+function cn(...inputs: ClassValue[]) {
+    return twMerge(clsx(inputs));
+}
+
+interface QuickRepeatButtonProps {
+    lastScorer: LastScorerState;
+    onQuickRepeat: () => void;
+    className?: string;
+}
+
+export function QuickRepeatButton({ lastScorer, onQuickRepeat, className }: QuickRepeatButtonProps) {
+    if (!lastScorer.playerId || !lastScorer.playerName) return null;
+
+    const teamColor = lastScorer.team === 'home' ? 'bg-orange-500/20 border-orange-500/50 text-orange-500' : 'bg-slate-500/20 border-slate-400/50 text-slate-300';
+
+    return (
+        <AnimatePresence>
+            <motion.button
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: 20 }}
+                transition={{ duration: 0.2 }}
+                onClick={onQuickRepeat}
+                className={cn(
+                    'fixed bottom-24 left-1/2 -translate-x-1/2 z-50',
+                    'flex items-center gap-2 px-4 py-3 rounded-full',
+                    'border-2 shadow-lg shadow-black/20',
+                    'active:scale-95 transition-all',
+                    teamColor,
+                    'landscape:bottom-4 landscape:right-4 landscape:left-auto landscape:translate-x-0',
+                    className
+                )}
+            >
+                <Repeat size={18} />
+                <span className="font-bold text-sm whitespace-nowrap">
+                    Score Again: #{lastScorer.playerName} ({lastScorer.points}pt)
+                </span>
+            </motion.button>
+        </AnimatePresence>
+    );
+}

--- a/src/components/scorer/scoring-modal.tsx
+++ b/src/components/scorer/scoring-modal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { X, Users, ArrowLeftRight, Shirt } from 'lucide-react';
+import { X, Users, ArrowLeftRight, Shirt, Check } from 'lucide-react';
 import { clsx, type ClassValue } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 import { motion, AnimatePresence } from 'framer-motion';
@@ -27,7 +27,7 @@ type Game = {
 
 interface ScoringModalProps {
     game: Game;
-    scoringFor: { points: number; isMiss?: boolean; side?: 'home' | 'guest' };
+    scoringFor: { points: number; isMiss?: boolean; side?: 'home' | 'guest'; preSelectedPlayerId?: string };
     onClose: () => void;
     onScore: (playerId: string | null, team: 'home' | 'guest') => void;
 }
@@ -37,20 +37,19 @@ export function ScoringModal({ game, scoringFor, onClose, onScore }: ScoringModa
 
     const activePlayers = game.rosters.filter(
         r => r.team === selectedTeam && r.isActive
-    ).slice(0, 5); // Limit to 5
+    ).slice(0, 5);
 
-    // Fill remaining slots if less than 5 active players (shouldn't happen with proper bench selection)
     const slots = [...activePlayers];
 
-    // When guest team is selected, skip player selection and score for team only
-    // When home team has no active players, also skip player selection
+    const preSelectedPlayer = scoringFor.preSelectedPlayerId 
+        ? game.rosters.find(r => r.id === scoringFor.preSelectedPlayerId)
+        : null;
+
     const handleTeamSelect = (team: 'home' | 'guest') => {
         const activeHome = game.rosters.filter(r => r.team === 'home' && r.isActive);
         if (team === 'guest' || (team === 'home' && activeHome.length === 0)) {
-            // No players to pick — score directly for the team
             onScore(null, team);
         } else {
-            // For home team with active players, show player selection
             setSelectedTeam(team);
         }
     };
@@ -75,6 +74,11 @@ export function ScoringModal({ game, scoringFor, onClose, onScore }: ScoringModa
                                 ? (selectedTeam === 'home' ? game.homeTeamName : game.guestTeamName)
                                 : 'WHICH TEAM?'}
                         </span>
+                        {preSelectedPlayer && selectedTeam && (
+                            <span className="text-sm font-normal text-slate-400 ml-2">
+                                (#{preSelectedPlayer.number})
+                            </span>
+                        )}
                     </h3>
                     <button onClick={onClose} className="p-3 text-slate-400 hover:text-white bg-card rounded-full transition-all active:scale-95">
                         <X size={24} />
@@ -107,28 +111,38 @@ export function ScoringModal({ game, scoringFor, onClose, onScore }: ScoringModa
                     /* 6-Player Grid */
                     <div className="grid grid-cols-2 grid-rows-3 gap-3 flex-1 h-full">
                         {/* 5 Player Slots */}
-                        {slots.map((player) => (
-                            <button
-                                key={player.id}
-                                onClick={() => onScore(player.id, selectedTeam)}
-                                className={cn(
-                                    "relative rounded-2xl flex flex-col items-center justify-center p-4 transition-all active:scale-95 border-2",
-                                    selectedTeam === 'home' 
-                                        ? "bg-input border-border hover:border-orange-500" 
-                                        : "bg-input border-border hover:border-slate-400"
-                                )}
-                            >
-                                <span className={cn(
-                                    "text-5xl font-black mb-1",
-                                    selectedTeam === 'home' ? "text-orange-500" : "text-slate-300"
-                                )}>
-                                    {player.number}
-                                </span>
-                                <span className="text-xs font-bold uppercase truncate w-full text-center text-slate-500">
-                                    {player.name}
-                                </span>
-                            </button>
-                        ))}
+                        {slots.map((player) => {
+                            const isPreSelected = preSelectedPlayer?.id === player.id;
+                            return (
+                                <button
+                                    key={player.id}
+                                    onClick={() => onScore(player.id, selectedTeam)}
+                                    className={cn(
+                                        "relative rounded-2xl flex flex-col items-center justify-center p-4 transition-all active:scale-95 border-2",
+                                        isPreSelected 
+                                            ? "bg-orange-500/20 border-orange-500 ring-2 ring-orange-500/50"
+                                            : selectedTeam === 'home' 
+                                                ? "bg-input border-border hover:border-orange-500" 
+                                                : "bg-input border-border hover:border-slate-400"
+                                    )}
+                                >
+                                    {isPreSelected && (
+                                        <div className="absolute top-2 right-2 bg-orange-500 rounded-full p-1">
+                                            <Check size={12} className="text-white" />
+                                        </div>
+                                    )}
+                                    <span className={cn(
+                                        "text-5xl font-black mb-1",
+                                        selectedTeam === 'home' ? "text-orange-500" : "text-slate-300"
+                                    )}>
+                                        {player.number}
+                                    </span>
+                                    <span className="text-xs font-bold uppercase truncate w-full text-center text-slate-500">
+                                        {player.name}
+                                    </span>
+                                </button>
+                            );
+                        })}
 
                         {/* 6th Slot: Opponent (Switch to Guest and Score) */}
                         <button

--- a/src/components/scorer/simple-scorer.tsx
+++ b/src/components/scorer/simple-scorer.tsx
@@ -136,7 +136,7 @@ export function SimpleScorer({ game, handleScore, handleFoul }: SimpleScorerProp
                 <div className="grid grid-cols-2 gap-4">
                     <button
                         onClick={() => handleFoul('home')}
-                        className="bg-red-500/10 border border-red-500/20 hover:bg-red-500/20 active:scale-95 transition-all rounded-2xl p-4 font-black flex justify-between items-center text-red-500"
+                        className="bg-red-500/10 border border-red-500/20 hover:bg-red-500/20 active:scale-95 transition-all rounded-2xl p-6 font-black flex justify-between items-center text-red-500"
                         data-testid="foul-btn-home"
                     >
                         <span className="text-[10px] uppercase tracking-widest">Foul</span>
@@ -144,7 +144,7 @@ export function SimpleScorer({ game, handleScore, handleFoul }: SimpleScorerProp
                     </button>
                     <button
                         onClick={() => handleFoul('guest')}
-                        className="bg-input border border-border hover:bg-card active:scale-95 transition-all rounded-2xl p-4 font-black flex justify-between items-center"
+                        className="bg-input border border-border hover:bg-card active:scale-95 transition-all rounded-2xl p-6 font-black flex justify-between items-center"
                         data-testid="foul-btn-guest"
                     >
                         <span className="text-[10px] uppercase tracking-widest text-slate-500">Foul</span>

--- a/src/lib/constants/touch-targets.ts
+++ b/src/lib/constants/touch-targets.ts
@@ -1,0 +1,33 @@
+/**
+ * Touch Target Constants - WCAG 2.5.5 Compliance
+ * Minimum sizes for accessibility during fast-paced basketball scoring.
+ */
+
+export const TOUCH_TARGETS = {
+  primary: 'min-h-[48px] min-w-[48px]',
+  secondary: 'min-h-[44px] min-w-[44px]',
+  icon: 'min-h-[32px] min-w-[32px] p-2',
+  inline: 'min-h-[28px] min-w-[28px] p-1',
+} as const;
+
+export const VISUAL_SIZES = {
+  periodPortrait: 'text-sm',
+  periodLandscape: 'text-xs',
+  clockPortrait: 'text-4xl',
+  clockLandscape: 'text-3xl',
+  gameLogAction: 20,
+  connectionIndicatorPortrait: 'w-3 h-3',
+  connectionIndicatorLandscape: 'w-2 h-2',
+} as const;
+
+export const ANIMATION_DURATIONS = {
+  mutationFeedback: 100,
+  debounceWindow: 300,
+  successFlash: 500,
+  errorToast: 10000,
+} as const;
+
+export const LANDSCAPE_THRESHOLDS = {
+  narrowDevice: 600,
+  tabletMin: 768,
+} as const;

--- a/src/lib/types/scorer-ui.ts
+++ b/src/lib/types/scorer-ui.ts
@@ -1,0 +1,34 @@
+/**
+ * UI State Types for Scorer Page UX Improvements
+ */
+
+export type PointsType = 1 | 2 | 3;
+
+export type Team = 'home' | 'guest';
+
+export type MutationType = 'score' | 'foul' | 'timeout' | 'sub';
+
+export type ExpirationTrigger = 'substitution' | 'timeout' | 'period_end';
+
+export interface LastScorerState {
+  playerId: string | null;
+  playerName: string | null;
+  team: Team | null;
+  points: PointsType | null;
+  timestamp: number;
+}
+
+export interface PendingMutation {
+  id: string;
+  type: MutationType;
+  target: string;
+  startedAt: number;
+}
+
+export interface MutationFeedbackState {
+  pending: Set<string>;
+  lastSuccess: { type: string; timestamp: number } | null;
+  lastError: { type: string; message: string } | null;
+}
+
+export type ClearTrigger = 'substitution' | 'timeout' | 'period_end' | 'team_change';


### PR DESCRIPTION
## Summary
- Add responsive text sizing for landscape buttons (scales on larger screens like iPad Air)
- Make scoring buttons equal size (+/- buttons now match)
- Increase touch targets to WCAG 2.5.5 standards (44x44pt minimum)
- Improve foul/subs/timeout button consistency
- Add mutation feedback component for loading states
- Sharpen button corners (rounded-2xl → rounded-lg)
- Bump version to 0.2.1-alpha